### PR TITLE
feat: enhance dev-container setup and variable export

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,9 @@
             "extensions": [
                 "tintinweb.vscode-vyper",
                 "trailofbits.weaudit",
-                "ms-python.python"
+                "ms-python.python",
+                "charliermarsh.ruff",
+                "tamasfe.even-better-toml"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "zsh",
@@ -24,11 +26,13 @@
                     "zsh": {
                         "path": "/usr/bin/zsh"
                     }
-                }
+                },
+                "python.terminal.activateEnvironment": true,
+                "python.defaultInterpreterPath": ".venv/bin/python"
             }
         }
     },
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "uv venv && source .venv/bin/activate && uv sync --all-extras"
+    "postCreateCommand": "zsh -c 'uv venv && source .venv/bin/activate && uv sync --all-extras'"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
     "files.exclude": {
         "**/__pycache__": true
     },
-    "python.terminal.activateEnvironment": false,
     "python.terminal.executeInFileDir": true
 }


### PR DESCRIPTION
Improve the dev-container setup by ensuring local environment variables can be exported and activating the Python virtual environment in the terminal. Fix issues related to shell commands and enhance the development experience with additional tools.

---

No issue related but proposal for dev experience with container on VSCode